### PR TITLE
compatibility to go 1.5.1

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,9 +38,9 @@ var format = logging.MustStringFormatter(
 	"%{color}%{time:15:04:05.000} %{shortfunc} [%{level:.5s}]:%{color:reset} %{message}",
 )
 
-var silentLogger struct{}
-
-func (silentLogger) Printf(format string, a ...interface{}) {}
+type SilentLogger struct{}
+func (s *SilentLogger) Printf(format string, a ...interface{}) {}
+var silentLogger = &SilentLogger{}
 
 func init() {
 	backend := logging.NewLogBackend(os.Stderr, "", 0)

--- a/client.go
+++ b/client.go
@@ -38,8 +38,9 @@ var format = logging.MustStringFormatter(
 	"%{color}%{time:15:04:05.000} %{shortfunc} [%{level:.5s}]:%{color:reset} %{message}",
 )
 
-type SilentLogger struct{}
-func (s *SilentLogger) Printf(format string, a ...interface{}) {}
+type silentLogger struct{}
+
+func (silentLogger) Printf(format string, a ...interface{}) {}
 
 func init() {
 	backend := logging.NewLogBackend(os.Stderr, "", 0)
@@ -47,7 +48,7 @@ func init() {
 	logging.SetBackend(backendFormatter)
 
 	logging.SetLevel(logging.INFO, "hbase-client")
-	zk.DefaultLogger = &SilentLogger{}
+	zk.DefaultLogger = &silentLogger{}
 }
 
 func NewClient(zkHosts []string, zkRoot string) *Client {

--- a/client.go
+++ b/client.go
@@ -40,7 +40,6 @@ var format = logging.MustStringFormatter(
 
 type SilentLogger struct{}
 func (s *SilentLogger) Printf(format string, a ...interface{}) {}
-var silentLogger = &SilentLogger{}
 
 func init() {
 	backend := logging.NewLogBackend(os.Stderr, "", 0)
@@ -48,7 +47,7 @@ func init() {
 	logging.SetBackend(backendFormatter)
 
 	logging.SetLevel(logging.INFO, "hbase-client")
-	zk.DefaultLogger = silentLogger
+	zk.DefaultLogger = &SilentLogger{}
 }
 
 func NewClient(zkHosts []string, zkRoot string) *Client {


### PR DESCRIPTION
```
[work@host ] $ go get github.com/Lazyshot/go-hbase
# github.com/Lazyshot/go-hbase
../../gospace/src/github.com/Lazyshot/go-hbase/client.go:43: silentLogger is not a type
[work@host ] $ go version
go version go1.5.1 linux/amd64
```
It seems that the declaration of silentLogger isn't compatible to go 1.5.