### PR TITLE
add time_range support to scan and fix a problem with start row

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -50,7 +50,7 @@ func init() {
 	// because golang's internal time represent is from Jan 1st, 1
 	// so if we want the max timestamp, we have to minus time.unixToInternal
 	// and as hbase accept a microsecond based timestamp, we divided it by 1000
-	maxTimestamp = time.Unix((math.MaxInt64-unixToInternal)/1000, 0)
+	maxTimestamp = time.Unix((math.MaxInt64-unixToInternal)/1e9, 0)
 }
 
 func newScan(table []byte, client *Client) *Scan {
@@ -201,8 +201,8 @@ func (s *Scan) getData(nextStart []byte) []*ResultRow {
 		}
 		if s.timeRange != nil {
 			req.Scan.TimeRange = &proto.TimeRange{
-				From: pb.Uint64(uint64(s.timeRange.From.Unix()) * 1000),
-				To:   pb.Uint64(uint64(s.timeRange.To.Unix()) * 1000),
+				From: pb.Uint64(uint64(s.timeRange.From.UnixNano() / 1e6)),
+				To:   pb.Uint64(uint64(s.timeRange.To.UnixNano() / 1e6)),
 			}
 		}
 	}

--- a/scan.go
+++ b/scan.go
@@ -193,11 +193,12 @@ func (s *Scan) getData(nextStart []byte) []*ResultRow {
 	if s.id > 0 {
 		req.ScannerId = pb.Uint64(s.id)
 	} else {
-		if s.StartRow != nil && s.StopRow != nil {
+		if s.StartRow != nil {
 			req.Scan.StartRow = s.StartRow
+		}
+		if s.StopRow != nil {
 			req.Scan.StopRow = s.StopRow
 		}
-
 		if s.timeRange != nil {
 			req.Scan.TimeRange = &proto.TimeRange{
 				From: pb.Uint64(uint64(s.timeRange.From.Unix()) * 1000),

--- a/types.go
+++ b/types.go
@@ -1,6 +1,8 @@
 package hbase
 
 import (
+	"time"
+
 	pb "github.com/golang/protobuf/proto"
 )
 
@@ -29,4 +31,9 @@ func (*exception) ProtoMessage()    {}
 type TableInfo struct {
 	TableName string
 	Families  []string
+}
+
+type TimeRange struct {
+	From time.Time
+	To   time.Time
 }


### PR DESCRIPTION
- add three function to Scan to support TimeRange Scan
```
func (s *Scan) SetTimeRange(from time.Time, to time.Time)
func (s *Scan) SetTimeRangeFrom(from time.Time)
func (s *Scan) SetTimeRangeTo(to time.Time)
```
In my use case, I only want to calculate the data which was written into hbase in the pass hour. So if I don't set a time range, the client has to read all data from hbase. If the data in hbase is too large, it would cost lots of time. Example:
```
scan.SetTimeRange(
        time.Unix(1450195200, 0),
        time.Unix(1450454400, 0),
)
```

- fix set start row only bug
```
// in scan.go:143
} else if s.StartRow != nil && s.StopRow != nil {
```
In scan.go:143, it pack StartRow/StopRow only if we set them both.
```
// in scan.go:224~226
if startRow == nil {
    startRow = s.StartRow
}
```
But in next() method, StartRow will be used. So if I only set a StartRow, it would be nextStart to next region server. But as I didn't set StopRow, the StartRow wouldn't send to the first server. So the first server may return the data I don't want.
On the other hand, I think it is reasonable to set just a StartRow or EndRow. HBase's rowkey has a dictionary order, so its rowkey is meaningful and has a strict order. Sometimes, if there was a panic when I iterated the hbase. When I solved the problem, I can continue to iterate hbase from where it panic last time.