### PR TITLE
Add user's specified timestamp support to Put

### DIFF
--- a/put.go
+++ b/put.go
@@ -12,6 +12,7 @@ type Put struct {
 	families   [][]byte
 	qualifiers [][][]byte
 	values     [][][]byte
+	timestamp  [][]int64
 }
 
 func CreateNewPut(key []byte) *Put {
@@ -20,26 +21,37 @@ func CreateNewPut(key []byte) *Put {
 		families:   make([][]byte, 0),
 		qualifiers: make([][][]byte, 0),
 		values:     make([][][]byte, 0),
+		timestamp:  make([][]int64, 0),
 	}
 }
 
 func (this *Put) AddValue(family, column, value []byte) {
+	this.AddValueTS(family, column, value, 0)
+}
+
+func (this *Put) AddValueTS(family, column, value []byte, ts int64) {
 	pos := this.posOfFamily(family)
 
 	if pos == -1 {
 		this.families = append(this.families, family)
 		this.qualifiers = append(this.qualifiers, make([][]byte, 0))
 		this.values = append(this.values, make([][]byte, 0))
+		this.timestamp = append(this.timestamp, make([]int64, 0))
 
 		pos = this.posOfFamily(family)
 	}
 
 	this.qualifiers[pos] = append(this.qualifiers[pos], column)
 	this.values[pos] = append(this.values[pos], value)
+	this.timestamp[pos] = append(this.timestamp[pos], ts)
 }
 
 func (this *Put) AddStringValue(family, column, value string) {
-	this.AddValue([]byte(family), []byte(column), []byte(value))
+	this.AddValueTS([]byte(family), []byte(column), []byte(value), 0)
+}
+
+func (this *Put) AddStringValueTS(family, column, value string, ts int64) {
+	this.AddValueTS([]byte(family), []byte(column), []byte(value), ts)
 }
 
 func (this *Put) posOfFamily(family []byte) int {
@@ -63,10 +75,14 @@ func (this *Put) toProto() pb.Message {
 		}
 
 		for j, _ := range this.qualifiers[i] {
-			cv.QualifierValue = append(cv.QualifierValue, &proto.MutationProto_ColumnValue_QualifierValue{
+			qv := &proto.MutationProto_ColumnValue_QualifierValue{
 				Qualifier: this.qualifiers[i][j],
 				Value:     this.values[i][j],
-			})
+			}
+			if this.timestamp[i][j] > 0 {
+				qv.Timestamp = pb.Uint64(uint64(this.timestamp[i][j]))
+			}
+			cv.QualifierValue = append(cv.QualifierValue, qv)
 		}
 
 		p.ColumnValue = append(p.ColumnValue, cv)

--- a/put.go
+++ b/put.go
@@ -29,6 +29,7 @@ func (this *Put) AddValue(family, column, value []byte) {
 	this.AddValueTS(family, column, value, 0)
 }
 
+// AddValueTS use user specified timestamp
 func (this *Put) AddValueTS(family, column, value []byte, ts int64) {
 	pos := this.posOfFamily(family)
 
@@ -50,6 +51,7 @@ func (this *Put) AddStringValue(family, column, value string) {
 	this.AddValueTS([]byte(family), []byte(column), []byte(value), 0)
 }
 
+// AddStringValueTS use user specified timestamp
 func (this *Put) AddStringValueTS(family, column, value string, ts int64) {
 	this.AddValueTS([]byte(family), []byte(column), []byte(value), ts)
 }


### PR DESCRIPTION
My app is based on time-rang-scan. So when added some new qualifier and value of an existing row key, I hope that it still have the same timestamp. I noticed that `Put` can not specify timestamp now, so I add two method to support it.
```
func (this *Put) AddValueTS(family, column, value []byte, ts int64)
func (this *Put) AddStringValueTS(family, column, value string, ts int64)
```
The origin AddValue/AddStringValue should not be influenced.

I noticed that the Timestamp(time.Time) in ResultRowColumn is based on millisecond which is different from golang's idiomatic time.Time. So I decided just use int64 as parameter type rather than time.Time. Because golang's time.Time is base on second and nanosecond, which hbase is base on millisecond, and it is difficult to transform precisely.

Hope your opinions.